### PR TITLE
[Feat] Add multiple api requests to frontend

### DIFF
--- a/serving/frontend/src/pages/UploadVideo.js
+++ b/serving/frontend/src/pages/UploadVideo.js
@@ -51,7 +51,7 @@ function UploadVideo() {
     navigate("/select-person", {
       state: res
     });
-  }
+  };
 
   const uploadModule = async (e) => {
     e.preventDefault();
@@ -65,24 +65,60 @@ function UploadVideo() {
       setLoading(true);
     }
 
-    const URL = "http://118.67.130.53:30001/upload-video";
+    const getFaceClustering = () => {
+      return axios({
+        method: "post",
+        url: "http://118.67.130.53:30001/upload-video",
+        data: formData,
+        headers: {
+          "Content-Type": "multipart/form-data",
+        }
+      });
+    };
 
-    await axios({
-      method: "post",
-      url: URL,
-      data: formData,
-      headers: {
-        "Content-Type": "multipart/form-data",
-      }
-    }).then((response) => {
-      setLoading(false);
-      setNext(true);
-      setRes(response.data)
-      console.log(response);
-    }).catch((error) => {
-      console.log('Failure :(');
-    });
-  }
+    const getLaughterDetection = () => {
+      return axios({
+        method: "post",
+        url: "http://118.67.130.53:30003/timeline-laughter",
+        data: formData,
+        headers: {
+          "Content-Type": "multipart/form-data",
+        }
+      });
+    };
+
+    await axios.all([getFaceClustering(), getLaughterDetection()])
+      .then(axios.spread(function (face_clustering, laughter_detection) {
+          setLoading(false);
+          setNext(true);
+          var tmp = { ...face_clustering.data};
+          tmp["laughter_timeline"] = laughter_detection.data.laughter_timeline;
+          setRes(tmp);
+          console.log(tmp);
+      })).catch((error) => {
+        console.log("Failure :(");
+      });
+
+
+    // === executing only face clustering ===
+    // const URL = "http://118.67.130.53:30001/upload-video";
+
+    // await axios({
+    //   method: "post",
+    //   url: URL,
+    //   data: formData,
+    //   headers: {
+    //     "Content-Type": "multipart/form-data",
+    //   }
+    // }).then((response) => {
+    //   setLoading(false);
+    //   setNext(true);
+    //   setRes(response.data)
+    //   console.log(response);
+    // }).catch((error) => {
+    //   console.log('Failure :(');
+    // });
+  };
 
   return (
     <div style={{padding: "20px"}}>
@@ -92,7 +128,7 @@ function UploadVideo() {
         <p style={{color: '#777777'}}>인물을 선택하면 </p>
         <p style={{color: '#aaaaaa'}}>#눈#사람이 자동으로 쇼츠를 추출합니다.</p>
       </StyledIntro>
-      <Spin spinning={loading} size="large" tip="Extracting faces...">
+      <Spin spinning={loading} size="large" tip="Extracting faces and laughter timeline...">
         <StyledUpload>
           <form onSubmit={uploadModule}>
             <p style={{fontSize: '18px', color: '#707070', fontWeight: 'bold'}}>원본 영상을 업로드해주세요.</p>


### PR DESCRIPTION
## 기능 설명 
- frontend에서 backend의 `/upload-video`와 `/timeline-laughter` api에 동시에 post request를 보내고, 두 response가 frontend로 모두 도착해야만 다음 단계인 `select-person`으로 넘어갈 수 있도록 하였습니다. (**multi-api**)
- `select-person`으로 넘어갈 때 넘겨주는 내용에 `laughter_timeline`을 추가했습니다. 해당 내용(`res`)의 예시 내용은 다음과 같습니다.

  ```json
  {
      "id": "3e7bd077-07ee-478d-8814-2e01a0105080",
      "file_name": "radio-star-20141001_short.mp4",
      "created_at": "2022-05-27T17:25:35.370654",
      "laughter_timeline": [
          [
              8.45,
              41.41,
              1
          ],
          [
              42.46,
              76.67075,
              1
          ]
      ],
      "video": "blob:http://34.64.107.58:30002/d962349d-6a8f-4c3b-83cf-57df0f6a4269"
  }
  ```

<br>


## 이미지 첨부 (Optional)
> 오른쪽 콘솔에 찍힌 값을 보시면 `laughter_timeline`이 전달되었음을 확인할 수 있습니다.

![Untitled (1)](https://user-images.githubusercontent.com/43572543/170764831-b851d20f-176b-4d10-b4f8-316ab2b879f0.png)

<br>


## Key Changes
- `serving/frontend/src/pages/UploadVideo.js`

<br>


## Related Issue
- #20 

<br>


## To Reviewers 
- frontend와 backend가 다른 서버에 존재하기 때문에 이렇게 브랜치를 나누어서 pull request를 따로 올립니다.

