### PR TITLE
[Feat] Add config.js for managing URLs

### DIFF
--- a/serving/frontend/.gitignore
+++ b/serving/frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+config.js

--- a/serving/frontend/src/components/Message.js
+++ b/serving/frontend/src/components/Message.js
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react";
 import axios from 'axios';
+import { FACE_API } from '../config';
 
 export default function Message() {
 
     const [result, setResult] = useState(null);
     const message = async () => {
         try {
-            let res = await axios.get('http://101.101.218.23:30001/');
+            let res = await axios.get(`${FACE_API}/`);
             let result = res.data["message"];
             setResult(result);
         } catch(e) {

--- a/serving/frontend/src/components/PeoplePanel.js
+++ b/serving/frontend/src/components/PeoplePanel.js
@@ -3,9 +3,8 @@ import axios from 'axios';
 import { useState } from 'react';
 import styled from "styled-components";
 import { useNavigate } from 'react-router-dom';
+import { STORAGE, FACE_API, LAUGHTER_API } from '../config';
 
-
-const STORAGE = "https://storage.googleapis.com/snowman-bucket/";
 
 function PeoplePanel(props) {
 
@@ -45,7 +44,7 @@ function PeoplePanel(props) {
 
     const getHighlight = async(res) => {
         await axios.post(
-            "http://118.67.130.53:30001/timeline-highlight", res // 101.101.218.23
+            `${FACE_API}/timeline-highlight`, res
         ).then((response) => {
             console.log(response);
             setLoading(false);
@@ -58,7 +57,7 @@ function PeoplePanel(props) {
         const FaceTimeline = () => {
             return axios({
                 method:"post",
-                url : "http://118.67.130.53:30001/timeline-face", // 101.101.218.23
+                url : `${FACE_API}/timeline-face`, 
                 data : {"face": checkedList, "id":props.id}
             });
         };
@@ -66,7 +65,7 @@ function PeoplePanel(props) {
         const LaughTimeline = () => {
             return axios({
                 method: "post",
-                url : "http://118.67.130.53:30003/timeline-laughter",
+                url : `${LAUGHTER_API}/timeline-laughter`,
                 data : {"id" : props.id_laughter}
             });
         };

--- a/serving/frontend/src/config.js.template
+++ b/serving/frontend/src/config.js.template
@@ -1,0 +1,6 @@
+// 본 파일을 복제하고 "config.js"로 파일 이름을 변경한 후, 개발 환경에서 사용할 URL을 설정하세요.
+// "config.js" 파일은 .gitignore에 등록되어 repository에 업로드되지 않습니다.
+
+export const STORAGE = ''; // ex) 'https://storage.googleapis.com/snowman-bucket/'
+export const FACE_API = ''; // ex) 'http://101.101.218.23:30001'
+export const LAUGHTER_API = ''; // ex) 'http://118.67.130.53:30003'

--- a/serving/frontend/src/pages/SelectVideo.js
+++ b/serving/frontend/src/pages/SelectVideo.js
@@ -4,10 +4,7 @@ import { Col, Row, Checkbox } from 'antd';
 import { DownloadPanel } from '../components';
 import { Video } from '../components';
 import { useLocation } from 'react-router-dom';
-
-
-// const STORAGE = "https://storage.googleapis.com/snowman-storage/";
-const URL = "https://storage.googleapis.com/snowman-bucket/";
+import { STORAGE } from '../config';
 
 
 function SelectVideo() {
@@ -30,7 +27,7 @@ function SelectVideo() {
         for (var i in shorts) {
             cards.push(
                 <Col xxl={8} xl={8} lg={12} md={12} xs={24} key={i} style={{display: "flex"}}>
-                    <Video index={i} shorts={shorts} URL={URL} response={location.state} />
+                    <Video index={i} shorts={shorts} URL={STORAGE} response={location.state} />
                 </Col>
             );
         };
@@ -68,7 +65,7 @@ function SelectVideo() {
                             </Row>
                         </Checkbox.Group>
                     </div>
-                    <DownloadPanel URL={URL} response={location.state} checkedList={checkedList} 
+                    <DownloadPanel URL={STORAGE} response={location.state} checkedList={checkedList} 
                                     checkAll={checkAll} onCheckAll={onCheckAllChange}/>
                 </StyledArea> 
             ) }

--- a/serving/frontend/src/pages/UploadVideo.js
+++ b/serving/frontend/src/pages/UploadVideo.js
@@ -4,6 +4,8 @@ import axios from 'axios';
 import { Spin, Upload, message } from 'antd';
 import { InboxOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
+import { FACE_API, LAUGHTER_API } from '../config';
+
 
 const { Dragger } = Upload;
 
@@ -49,7 +51,7 @@ function UploadVideo() {
     const getFaceClustering = () => {
       return axios({
         method: "post",
-        url: "http://101.101.218.23:30001/upload-video", //101.101.218.23
+        url: `${FACE_API}/upload-video`, 
         data: formData,
         headers: {
           "Content-Type": "multipart/form-data",
@@ -60,7 +62,7 @@ function UploadVideo() {
     const getLaughterDetection = () => {
       return axios({
         method: "post",
-        url: "http://118.67.130.53:30003/upload-video",
+        url: `${LAUGHTER_API}/upload-video`,
         data: formData,
         headers: {
           "Content-Type": "multipart/form-data",
@@ -69,7 +71,7 @@ function UploadVideo() {
     };
 
     const getPeopleImg = (res) => {
-      return axios.get("http://101.101.218.23:30001/show-people", {params: {"id":  res}}
+      return axios.get(`${FACE_API}/show-people`, {params: {"id":  res}}
       ).then((response) => {
         console.log(response);
         setPeople(response.data.people_img)
@@ -110,8 +112,6 @@ function UploadVideo() {
               <InboxOutlined />
             </p>
             <p style={{fontSize: '18px', color: '#707070', fontWeight: 'bold'}}>원본 영상을 업로드해주세요.</p>
-            {/* <input type="file" accept="video/*" name="file" />
-            <input type="submit" value="SUBMIT" /> */}
           </Dragger>
         </StyledUpload>
       </Spin>


### PR DESCRIPTION
## 기능 설명 
- 개발 환경에서의 API 및 STORAGE의 URL들을 관리하기 위한 config 템플릿 파일을 작성하였습니다.
- 사용 방법은 밑의 To Reviewers에 적어두겠습니다.

<br>


## Key Changes
- `config.js.template`
- API 및 STORAGE URL을 사용하는 파일들

<br>


## Related Issue
- #49 

<br>


## To Reviewers 
- `config.js.template`을 복제하여 파일 이름을 `config.js`로 바꾼 후, 내부의 `STORAGE`, `FACE_API`, `LAUGHTER_API`를 개발 환경에서 사용하는 URL로 설정하시면 됩니다. (주석은 삭제하셔도 됩니다.)
- `config.js`는 `.gitignore`에 등록되어 있으므로 `config.js`는 repository에 업로드 되지 않기 때문에 각자의 개발환경에 맞는 URL을 별도의 코드 수정 없이 계속 사용하실 수 있습니다.
- 추후 backend에서 사용하는 GCS 용 secret json 파일도 따로 관리를 해야할 것 같습니다.
- 나중에 deploy 시에는 `.env.development`와 `.env.production`으로 다시 수정하여 관리해야 할 것 같습니다.

<br>
