### PR TITLE
[Feat] Resolve avatar overlapping problem on DownloadPanel

### DIFF
--- a/serving/frontend/src/components/DownloadPanel.js
+++ b/serving/frontend/src/components/DownloadPanel.js
@@ -5,7 +5,6 @@ import axios from 'axios';
 
 const DownloadPanel = ({URL, response, checkedList, checkAll, onCheckAll}) => {
 
-    // people_img는 이걸로 이용하면 ok!
     const people_img = [...new Set(response.shorts.map(short => short[0]))];
     console.log(people_img);
 
@@ -71,7 +70,7 @@ const DownloadPanel = ({URL, response, checkedList, checkAll, onCheckAll}) => {
                     <StyledTitle>
                         쇼츠 내 인물 정보
                     </StyledTitle>
-                    <div style={{padding: "5px", marginTop: "5px", width:"100%", display: "flex"}}>
+                    <div style={{padding: "5px", marginTop: "5px", width:"100%"}}>
                         <Row gutter={5}>
                             {renderPeople(URL, response)}
                         </Row>


### PR DESCRIPTION
## 기능 설명 
- `DownloadPanel`에서 인물 정보 아바타가 겹치는 문제점을 해결하였습니다.

<br>


## 이미지 첨부 (Optional)
- **문제 상황** : `DownloadPanel`의 인물 아바타가 겹치는 현상
![](https://user-images.githubusercontent.com/43572543/172034955-67b894a6-19e1-4adb-90f1-9b931dee17e9.png)

- **해결 완료 후 화면**
![](https://user-images.githubusercontent.com/43572543/172035149-fd80421a-048c-44ad-b932-ec4d513eb110.png)

<br>


## Key Changes
- `snowman/serving/frontend/src/components/DownloadPanel.js`

<br>


## Related Issue
- #47

<br>


## To Reviewers 
- 현재 해결한 문제 외에도 두 인물의 쇼츠가 같은 영상일 때, 같은 영상이 중복해서 사용자에게 보여지는 문제점이 있습니다. 큰 문제점은 아니지만 추후 시간이 된다면 동일한 쇼츠에 대해서는 인물 사진을 하나로 모아 보여주는 식으로 해도 좋을 것 같습니다.

<br>
