### PR TITLE
[Feat] Modify ffmpeg code in make_shorts

### DIFF
--- a/serving/backend/app/ml/final_shorts/make_shorts.py
+++ b/serving/backend/app/ml/final_shorts/make_shorts.py
@@ -34,12 +34,19 @@ def make_shorts(final_highlights, total_length, id, target_person):
         HIGHLISHT_STORAGE_DIR = os.path.join(SHORTS_STORAGE_DIR, f"short_{target_person}_{idx}.mp4")
         blob = bucket.blob(HIGHLISHT_STORAGE_DIR)
 
-        (
-            in_file
-            .trim(start_frame=start, end_frame=end)
-            .output(HIGHLIGHT_PATH)
-            .run()
+        vid = (
+            in_file.video
+            .trim(start=start, end=end)
+            .setpts('PTS-STARTPTS')
         )
+        aud = (
+            in_file.audio
+            .filter_('atrim', start=start, end=end)
+            .filter_('asetpts', 'PTS-STARTPTS')
+        )
+        joined = ffmpeg.concat(vid, aud, v=1, a=1).node
+        output = ffmpeg.output(joined[0], joined[1], HIGHLIGHT_PATH)
+        output.run()
 
         # clip = VideoFileClip(VIDEO_DIR).subclip(start,end).fx(vfx.fadein,1).fx(vfx.fadeout,1)        
         


### PR DESCRIPTION
## 기능 설명 
- shorts 생성 시 final_timeline과 맞지 않고 음성이 없는 영상이 저장되는 문제를 해결하였습니다.

<br>


## Key Changes
- `serving/backend/app/ml/final_shorts/make_shorts.py`

<br>


## Related Issue
- #67 

<br>


## To Reviewers 
- 쇼츠 5개 생성에 1분 20~30초 정도 소요되는 것 같습니다. 더 실험이 필요할 것 같습니다.

<br>
