### PR TITLE
[Feat] Add context to separate laughter detection

### DIFF
--- a/serving/frontend/src/App.js
+++ b/serving/frontend/src/App.js
@@ -3,18 +3,35 @@ import './App.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { NavBar } from './components';
 import { UploadVideo, SelectPerson, SelectVideo } from './pages';
+import { LaughterContext } from './context';
+import React, { useState, useEffect } from 'react';
 
 
 function App() {
+
+  const [laughterTimeline, setLaughterTimeline] = useState();
+  const value = { laughterTimeline, setLaughterTimeline };
+
+  useEffect(() => {
+    if (laughterTimeline) {
+      console.log(laughterTimeline);
+    }
+    
+  }, [laughterTimeline]);
+
   return (
     <div className="App" style={{paddingTop: "50px"}}>
+      {/* <NavBar /> */}
       <BrowserRouter>
         <NavBar />
+        <LaughterContext.Provider value={value}>
         <Routes>
           <Route path="/" element={<UploadVideo />} />
           <Route path="/select-person" element={<SelectPerson />} />
           <Route path="/select-video" element={<SelectVideo />} />
         </Routes>
+        </LaughterContext.Provider>
+        {/** Footer */}
       </BrowserRouter>
     </div>
   );

--- a/serving/frontend/src/context/LaughterContext.js
+++ b/serving/frontend/src/context/LaughterContext.js
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+
+export const LaughterContext = createContext({
+    laughterTimeline: null,
+    setLaughterTimeline: () => {}
+});

--- a/serving/frontend/src/context/index.js
+++ b/serving/frontend/src/context/index.js
@@ -1,0 +1,3 @@
+import { LaughterContext } from "./LaughterContext";
+
+export { LaughterContext };


### PR DESCRIPTION
## 기능 설명 
- laughter detection과 face clustering/recognition을 분리하기 위해 `useContext`를 이용하여 구조를 수정하였습니다.
- laughter detection과 face recognition이 모두 완료되어야지만 final timeline을 추출하는 api로 요청을 보내도록 하였습니다.

<br>


## Key Changes
- serving/frontend/src/App.js
- serving/frontend/src/components/PeoplePanel.js
- serving/frontend/src/context/LaughterContext.js
- serving/frontend/src/context/index.js
- serving/frontend/src/pages/UploadVideo.js

<br>


## Related Issue
- #69 

<br>


## To Reviewers 
- laughter detection이 먼저 완료되어도, face recognition이 먼저 완료되어도 모두 잘 동작하는 것을 확인했습니다.

<br>
