### PR TITLE
[Feat] Add APIs using Youtube URL 

### DIFF
--- a/serving/backend/app/api/video.py
+++ b/serving/backend/app/api/video.py
@@ -5,6 +5,15 @@ from pydantic import BaseModel, Field
 from uuid import UUID, uuid4
 from datetime import datetime
 import shutil
+from pytube import YouTube
+from typing import Optional
+from fastapi.responses import JSONResponse
+
+from google.cloud import storage
+storage_client = storage.Client()
+bucket_name = 'snowman-bucket'
+bucket = storage_client.bucket(bucket_name)
+
 
 # # google cloud storage
 # from google.cloud import storage
@@ -28,7 +37,7 @@ class Video(BaseModel):
     
 
 @router.post("/upload-video", description="비디오를 업로드합니다.")
-async def create_video_file(file: UploadFile = File(...)):
+def create_video_file(file: UploadFile = File(...)):
     new_video = Video(file_name=file.filename)
     # video_contents = await file.read()
     os.makedirs(os.path.join(FILE_DIR, str(new_video.id)))
@@ -42,5 +51,38 @@ async def create_video_file(file: UploadFile = File(...)):
     return new_video
 
 
-# TODO: /upload-video (비디오를 서버에 업로드하는 과정)
-# TODO: /select-highlight (생성된 쇼츠를 다운로드 하는 과정)
+class YTVideo(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    video: Optional[str]
+    file_name: str
+    created_at : datetime = Field(default_factory=datetime.now)
+
+
+@router.post("/upload-video-youtube", description="유튜브 URL을 이용하여 비디오를 업로드합니다.")
+def create_video_file_from_youtube(info: dict):
+    yt_video = YouTube(info['url'])
+    new_video = YTVideo(file_name=yt_video.title + '.mp4')
+
+    stream = yt_video.streams.filter(progressive=True, subtype="mp4", resolution="720p").first()
+    if stream:
+        os.makedirs(os.path.join(FILE_DIR, str(new_video.id)))
+        id_path = os.path.join(FILE_DIR, str(new_video.id))
+        server_path = os.path.join(id_path, ('original.mp4'))
+
+        stream.download(output_path=id_path, filename='original.mp4')
+
+        # upload to gcs
+        blob_dir = os.path.join(str(new_video.id), 'youtube_original.mp4')
+        blob = bucket.blob(blob_dir)
+        blob.upload_from_filename(server_path)
+        new_video.video = os.path.join('https://storage.googleapis.com', bucket_name, blob_dir)
+
+        FaceClustering(server_path, os.path.join(id_path, 'result'))
+
+        return new_video
+
+    else:
+        return JSONResponse(
+            status_code=422,
+            content={"message": "720p를 지원하는 영상이 아닙니다."}
+        )

--- a/serving/backend/app_laughter/api/laughter.py
+++ b/serving/backend/app_laughter/api/laughter.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 from datetime import datetime
 import shutil
 from typing import List, Tuple, Optional
+from pytube import YouTube
 
 from ml.laughter_detection import LaughterDetection
 
@@ -23,46 +24,15 @@ class Video(BaseModel):
     created_at : datetime = Field(default_factory=datetime.now)
 
 
-@router.post("/upload-video", description="비디오를 업로드합니다.")
-async def create_video_file(file: UploadFile = File(...)):
-    # download the uploaded video
-    new_video = Video(file_name=file.filename)
-    os.makedirs(os.path.join(FILE_DIR, str(new_video.id_laughter)))
-    server_path = os.path.join(FILE_DIR, str(new_video.id_laughter), ('original' + os.path.splitext(file.filename)[1]))
-    with open(server_path, "wb") as buffer:
-        shutil.copyfileobj(file.file, buffer)
-
-    return new_video
-
-
 class VideoTimeline(BaseModel):
     id: UUID
     # file_name: str
     laugh: Optional[List[Tuple]]
     # created_at : datetime
-    
 
-@router.post("/timeline-laughter", description="laughter detection을 수행하여 laughter timeline을 추출합니다.")
-async def get_timeline_laughter(info: dict):
-    new_video_timeline = VideoTimeline(id=info['id'])
-    server_path = os.path.join(FILE_DIR, str(new_video_timeline.id))
-
-    # execute laughter detection    
-    wav_path = os.path.join(server_path, 'for_laughter_detection')
-    video_path = os.path.join(server_path, os.listdir(server_path)[0])
-
-    laughter_timeline = LaughterDetection(video_path, wav_path, ML_DIR)
-    new_video_timeline.laugh = laughter_timeline
-
-    # remove folder (laughter detection 서버에서는 일회성이므로)
-    shutil.rmtree(os.path.join(FILE_DIR, str(new_video_timeline.id)))
-    return new_video_timeline
-
-
-# TODO: /laughter-detection (기존의 /upload-video와 /timeline-laughter 통합)
 
 @router.post("/laughter-detection", description="laughter timeline을 추출하는 전과정을 수행합니다.")
-async def laughter_detection(file: UploadFile = File(...)):
+def laughter_detection(file: UploadFile = File(...)):
     # download the uploaded video
     new_video = Video(file_name=file.filename)
     os.makedirs(os.path.join(FILE_DIR, str(new_video.id_laughter)))
@@ -82,3 +52,33 @@ async def laughter_detection(file: UploadFile = File(...)):
     # remove folder (laughter detection 서버에서는 일회성이므로)
     shutil.rmtree(os.path.join(FILE_DIR, str(new_video_timeline.id)))
     return new_video_timeline
+
+
+@router.post("/laughter-detection-youtube", description="유튜브 URL을 이용하여 laughter timeline을 추출하는 전과정을 수행합니다.")
+def laughter_detection_from_youtube(info: dict):
+    yt_video = YouTube(info['url'])
+    new_video = Video(file_name=yt_video.title + '.mp4')
+
+    stream = yt_video.streams.filter(progressive=True, subtype="mp4", resolution="720p").first()
+    if stream:
+        os.makedirs(os.path.join(FILE_DIR, str(new_video.id_laughter)))
+        id_path = os.path.join(FILE_DIR, str(new_video.id_laughter))
+        video_path = os.path.join(id_path, ('original.mp4'))
+
+        stream.download(output_path=id_path, filename='original.mp4')
+
+        # extract laughter timeline
+        new_video_timeline = VideoTimeline(id=new_video.id_laughter)
+
+        # execute laughter detection    
+        wav_path = os.path.join(id_path, 'for_laughter_detection')
+
+        laughter_timeline = LaughterDetection(video_path, wav_path, ML_DIR)
+        new_video_timeline.laugh = laughter_timeline
+
+        # remove folder (laughter detection 서버에서는 일회성이므로)
+        shutil.rmtree(os.path.join(FILE_DIR, str(new_video_timeline.id)))
+        return new_video_timeline
+
+    else:
+        return {"message": "720p를 지원하는 영상이 아닙니다."}


### PR DESCRIPTION
## 기능 설명 
- `pytube`를 이용하여 Youtube 영상용 API인 `/upload-video-youtube`와 `/laughter-detection-youtube`를 작성하였습니다.
- 720p 이상 지원하지 않는 영상에 대해서는 예외 처리를 진행하였습니다. (`code 422`) 따라서 프론트에서 해당 메시지를 받아볼 수 있게 됩니다.

<br>


## Key Changes
- serving/backend/app/api/video.py
- serving/backend/app_laughter/api/laughter.py

<br>


## Related Issue
- #77 

<br>


## To Reviewers 
- 결국 youtube url의 CORB 문제를 해결하지 못해 GCS에 업로드 후 그 url을 가져오는 방식을 적용하였습니다. (시간이 오래 걸리는 건 체감하지 못했습니다.)
- `pytube`를 설치하는 방법은 다음과 같습니다.
  1. 다음의 명령어로 설치합니다.
  
      ```bash
      python -m pip install git+https://github.com/pytube/pytube
      ```
  2. `/opt/conda/lib/python3.8/site-packages/pytube/cipher.py`의 line 30을 다음과 같이 바꿉니다.
  
      ```python
      var_regex = re.compile(r"^\w+\W")  # 이 코드를
      var_regex = re.compile(r"^\$*\w+\W")  # 이렇게 바꿔주세요
      ```

<br>
