### PR TITLE
[Feat] Making shorts with ffmpeg-python

### DIFF
--- a/serving/backend/app/ml/final_shorts/final_timeline.py
+++ b/serving/backend/app/ml/final_shorts/final_timeline.py
@@ -19,13 +19,13 @@ def make_final_timeline(laughter_timeline,person_timeline,max_length=None):
             if length/shot_length > 0.35:
                 person_interest = (length/shot_length - 0.3)/0.4
                 total_interest = laugh_len*3 + laugh_db*2 + person_interest*1
-                final.append((round(start-5,2),end,round(total_interest,2),round(length/shot_length,3)))
+                final.append((round(start-5,2),end,round(total_interest,2),round(length/shot_length,3), shot_length))
                 total_length += shot_length
         else:
             if length/shot_length > 0.30:
                 person_interest = (length/shot_length - 0.3)/0.4
                 total_interest = laugh_len*3 + laugh_db*2 + person_interest*1
-                final.append((round(start-5,2),end,round(total_interest,2),round(length/shot_length,3)))
+                final.append((round(start-5,2),end,round(total_interest,2),round(length/shot_length,3), shot_length))
                 total_length += shot_length  
             
     # max_length 넘어가는 경우 흥미도 높은 순서로 max_length 이내로 선택
@@ -39,12 +39,12 @@ def make_final_timeline(laughter_timeline,person_timeline,max_length=None):
                 break
             else:
                 total_length += length
-                choose_index[final.index((start,end,interest,ratio))] = True
+                choose_index[final.index((start,end,interest,ratio,duration))] = True
                 
         new_final = []
-        for ind, (s,e,i,r) in enumerate(final):
+        for ind, (s,e,i,r,d) in enumerate(final):
             if choose_index[ind]:
-                new_final.append((s,e,i,r))
+                new_final.append((s,e,i,r,d))
         final = new_final
     
     # interest 순서로 정렬

--- a/serving/backend/app/ml/final_shorts/make_shorts.py
+++ b/serving/backend/app/ml/final_shorts/make_shorts.py
@@ -6,6 +6,7 @@ bucket_name = 'snowman-bucket'
 bucket = storage_client.bucket(bucket_name)
 
 import os
+import ffmpeg
 
 def make_shorts(final_highlights, total_length, id, target_person):
     print("Making Shorts....")
@@ -22,7 +23,7 @@ def make_shorts(final_highlights, total_length, id, target_person):
 
     # CURRENT_DIR = os.getcwd()
 
-    # in_file = ffmpeg.input(VIDEO_DIR)
+    in_file = ffmpeg.input(VIDEO_DIR)
 
     target_person_shorts = []
     for idx, (start, end, interest, during) in enumerate(final_highlights):
@@ -35,11 +36,23 @@ def make_shorts(final_highlights, total_length, id, target_person):
         
         trim_and_fade(VIDEO_DIR, start, end, HIGHLIGHT_PATH)
 
-        # clip = VideoFileClip(VIDEO_DIR).subclip(start,end).fx(vfx.fadein,1).fx(vfx.fadeout,1)        
-        
-        # os.chdir(SHORTS_DIR) # for saving [video-name]TEMP_MPY_wvf_snd.mp3 file in files/[uuid]/shorts
-        # clip.write_videofile(HIGHLIGHT_PATH)
-        # os.chdir(CURRENT_DIR) # come back to original directory
+        vid = (
+            in_file.video
+            .trim(start=start, end=end)
+            .fade(type="in", start_time=start, duration=1)
+            .fade(type="out", start_time=end-1, duration=1)
+            .setpts('PTS-STARTPTS')
+        )
+        aud = (
+            in_file.audio
+            .filter_('atrim', start=start, end=end)
+            .filter_('afade', type='in', start_time=start, duration=1)
+            .filter_('afade', type='out', start_time=end-1, duration=1)
+            .filter_('asetpts', 'PTS-STARTPTS')
+        )
+        joined = ffmpeg.concat(vid, aud, v=1, a=1).node
+        output = ffmpeg.output(joined[0], joined[1], HIGHLIGHT_PATH)
+        output.run()
 
         blob.upload_from_filename(HIGHLIGHT_PATH)
 
@@ -49,7 +62,11 @@ def make_shorts(final_highlights, total_length, id, target_person):
 
 
 def trim_and_fade(original_path, start, end, save_path):
-    os.system(f'ffmpeg -i {original_path} -ss {start} -to {end} -filter_complex \
-        "fade=in:st={start}:d=1, fade=out:st={end-1}:d=1; \
-        afade=in:st={start}:d=1, afade=out:st={end-1}:d=1" \
-        -c:v libx264 -c:a aac {save_path}')
+    print(f"start making {save_path}")
+    os.system(f'ffmpeg -ss {start} -i {original_path} -to {end} -filter_complex \
+         "fade=in:st={start}:d=1, fade=out:st={end-1}:d=1; \
+         afade=in:st={start}:d=1, afade=out:st={end-1}:d=1" \
+        -c:v copy -c:a copy {save_path}')
+    # os.system(f'ffmpeg -i {original_path} -vf "trim=start={start}:end={end}, fade=in:st={start}:d=1, fade=out:st={end-1}:d=1" \
+    #     -af "atrim=start={start}:end={end}, afade=in:st={start}:d=1, afade=out:st={end-1}:d=1"\
+    #      {save_path}')

--- a/serving/backend/app/ml/final_shorts/make_shorts.py
+++ b/serving/backend/app/ml/final_shorts/make_shorts.py
@@ -26,7 +26,7 @@ def make_shorts(final_highlights, total_length, id, target_person):
     in_file = ffmpeg.input(VIDEO_DIR)
 
     target_person_shorts = []
-    for idx, (start, end, interest, during) in enumerate(final_highlights):
+    for idx, (start, end, interest, ratio, during) in enumerate(final_highlights):
         print("Making Clips...")
         HIGHLIGHT_PATH = os.path.join(SHORTS_DIR, f"short_{target_person}_{idx}.mp4")
 


### PR DESCRIPTION
## 기능 설명 
- 기존의 command line으로 ffmpeg을 사용하였을 때, 쇼츠가 생성되는 시간이 너무 길었고, 이에 따라 ffmpeg-python을 다시 적용하기로 하였다.
- 추가적으로, ffmpeg-python의 내부함수에서 fade in/out을 추가하여, fade 효과가 가능하도록 설정하였다.
- short의 duration을 추가하여, frontend에서 각각의 영상들에 대한 길이를 출력할 수 있도록 하였다.

<br>


## Key Changes
- 

<br>


## Related Issue
close #67 

<br>


## To Reviewers 
fade in/out을 적용하기 위해서 아래와 같은 작업을 진행해야 된다.
`/opt/conda/lib/python3.8/site-packages/ffmpeg/_filters.py` 를 들어간 후, 아래의 함수를 추가한다.
```python
@filter_operator()
def fade(stream, **kwargs):
    """Fade in/out the input.

    Args:
        type: Specify the type of the fade. In or Out can be.
        start_time: Specify the time of the start of the fade effect.
        duration: Specify the time of the length of the fade effect.

    """
    return FilterNode(stream, fade.__name__, kwargs=kwargs).stream()
```

<br>
