### PR TITLE
[Fix] Add FileNotFoundError to upload-video api

### DIFF
--- a/serving/backend/app/api/highlight.py
+++ b/serving/backend/app/api/highlight.py
@@ -36,8 +36,6 @@ def read_highlight(timelines: dict):
 
     shorts = FinalTimeline(laugh_timeline, face_timeline, id)
 
-    print(shorts)
-
     if len(shorts)==0:
         return JSONResponse(
             status_code=422,

--- a/serving/backend/app/api/video.py
+++ b/serving/backend/app/api/video.py
@@ -44,8 +44,8 @@ def create_video_file(file: UploadFile = File(...)):
             created_at (datetime): 파일이 업로드된 시간.
     """
     new_video = Video(file_name=file.filename)
-    os.makedirs(os.path.join(FILE_DIR, str(new_video.id)))
     id_path = os.path.join(FILE_DIR, str(new_video.id))
+    os.makedirs(id_path)
     server_path = os.path.join(id_path, ('original' + os.path.splitext(file.filename)[1]))
 
     with open(server_path, 'wb') as buffer:
@@ -54,6 +54,15 @@ def create_video_file(file: UploadFile = File(...)):
     try:
         FaceClustering(server_path, os.path.join(id_path, 'result'))
     except ValueError as e:
+        # remove folder
+        shutil.rmtree(id_path)
+        return JSONResponse(
+            status_code=422,
+            content={"message" : "등장 인물을 추출하지 못했습니다. 다른 영상으로 시도해 주세요!"}
+        )
+    except FileNotFoundError as e:
+        # remove folder
+        shutil.rmtree(id_path)
         return JSONResponse(
             status_code=422,
             content={"message" : "등장 인물을 추출하지 못했습니다. 다른 영상으로 시도해 주세요!"}
@@ -88,8 +97,8 @@ def create_video_file_from_youtube(info: dict):
 
     stream = yt_video.streams.filter(progressive=True, subtype="mp4", resolution="720p").first()
     if stream:
-        os.makedirs(os.path.join(FILE_DIR, str(new_video.id)))
         id_path = os.path.join(FILE_DIR, str(new_video.id))
+        os.makedirs(id_path)
         server_path = os.path.join(id_path, ('original.mp4'))
 
         stream.download(output_path=id_path, filename='original.mp4')
@@ -103,6 +112,15 @@ def create_video_file_from_youtube(info: dict):
         try:
             FaceClustering(server_path, os.path.join(id_path, 'result'))
         except ValueError as e:
+            # remove folder
+            shutil.rmtree(id_path)
+            return JSONResponse(
+                status_code=422,
+                content={"message" : "등장 인물을 추출하지 못했습니다. 다른 영상으로 시도해 주세요!"}
+            )
+        except FileNotFoundError as e:
+            # remove folder
+            shutil.rmtree(id_path)
             return JSONResponse(
                 status_code=422,
                 content={"message" : "등장 인물을 추출하지 못했습니다. 다른 영상으로 시도해 주세요!"}

--- a/serving/backend/app/ml/face_functions.py
+++ b/serving/backend/app/ml/face_functions.py
@@ -23,7 +23,7 @@ def FaceClustering(video_path: str = "", save_dir:str = ""):
         video_path=video_path,
         data_dir=None,
         result_dir=save_dir,
-        threshold=0.65,
+        threshold=0.65, # demo 용
         face_cnt=280, # demo 용
         skip=60 # demo 용
     )

--- a/serving/backend/app_laughter/api/laughter.py
+++ b/serving/backend/app_laughter/api/laughter.py
@@ -27,9 +27,7 @@ class Video(BaseModel):
 
 class VideoTimeline(BaseModel):
     id: UUID
-    # file_name: str
     laugh: Optional[List[Tuple]]
-    # created_at : datetime
 
 
 @router.post("/laughter-detection", description="laughter timeline을 추출하는 전과정을 수행합니다.")
@@ -56,14 +54,6 @@ def laughter_detection(file: UploadFile = File(...)):
 
     # execute laughter detection    
     wav_path = os.path.join(FILE_DIR, str(new_video.id_laughter), 'for_laughter_detection')
-
-    # laughter_timeline = LaughterDetection(video_path, wav_path, ML_DIR)
-
-    # if laughter_timeline == None:
-    #     return JSONResponse(
-    #         status_code=422,
-    #         content={"message": "쇼츠를 생성할 수 없는 영상입니다. 다른 영상으로 시도해 주세요!"}
-    #     )
 
     try:
         laughter_timeline = LaughterDetection(video_path, wav_path, ML_DIR)
@@ -139,4 +129,4 @@ def laughter_detection_from_youtube(info: dict):
         return new_video_timeline
 
     else:
-        return {"message": "720p를 지원하는 영상이 아닙니다."}
+        return {"message": "720p를 지원하는 영상이 아닙니다."} # 어차피 app/api/video.py에서 예외 처리


### PR DESCRIPTION
## 기능 설명 
- `FileNotFoundError`를 추가하여 업로드된 영상에 얼굴이 없는 경우에 예외처리가 되지 않는 상황을 해결하였습니다.
- 영상 업로드후 메인 페이지에서 예외처리가 되는 경우, 업로드된 영상이 포함된 해당 uuid 폴더를 삭제하는 동작을 추가하였습니다.

<br>

## Related Issue
- #100

<br>
